### PR TITLE
Suggestion: link reasonConstructor highlight to Constant

### DIFF
--- a/syntax/reason.vim
+++ b/syntax/reason.vim
@@ -191,7 +191,7 @@ hi def link reasonCharacter     Character
 hi def link reasonNumber        Number
 hi def link reasonBoolean       Boolean
 hi def link reasonEnum          reasonType
-hi def link reasonConstructor   Function
+hi def link reasonConstructor   Constant
 hi def link reasonModPath       Include
 hi def link reasonConstant      Constant
 hi def link reasonSelf          Constant


### PR DESCRIPTION
This is what's done in `vim-ocaml` for `ocamlConstructor` and I think it
makes sense as constructors are kind of literal values.

Feel free to close if you disagree.