### PR TITLE
Fix console log for users with ":" mapped

### DIFF
--- a/autoload/console.vim
+++ b/autoload/console.vim
@@ -298,7 +298,7 @@ function! console#ShortHl(prefix, hl, msg)
   " destroys +=T
   " exe "norm :echomsg msgNotif | echohl airline_error | echon prefix | echohl None\n"
   " echohl airline_error
-  exe "norm :echomsg msgNotif | echohl " . a:hl . " | echon prefix\n"
+  exe "norm! :echomsg msgNotif | echohl " . a:hl . " | echon prefix\n"
   silent echohl None
   let &shortmess=saved
   " If the log file is opened just refresh it right now.


### PR DESCRIPTION
In my vimmrc i have:
```
nnoremap : ;
```
This was messing up the `exe "norm :echomsg ...` because `:norm` (without the bang) uses mappings, causing `:ReasonPrettyPrint` to end up inserting the text "omsg msgNotif | ..." sometimes.  (I'm not sure why this would only happen sometimes but not others (maybe ~5% of writes it would insert garbage)).